### PR TITLE
Update redis_fdw.c

### DIFF
--- a/redis_fdw.c
+++ b/redis_fdw.c
@@ -3362,6 +3362,9 @@ redisAddForeignUpdateTargets(
 		RangeTblEntry *target_rte,
 		Relation target_relation)
 {
+	#if PG_VERSION_NUM < 140000
+  	        TargetEntry *tle;
+	#endif
 	Oid relid = RelationGetRelid(target_relation);
 	TupleDesc tupdesc = target_relation->rd_att;
 	int i;
@@ -3501,7 +3504,7 @@ redisAddForeignUpdateTargets(
 			continue;
 
 #if PG_VERSION_NUM < 140000		
-		TargetEntry *tle;
+		/*TargetEntry *tle;*/
 		/* make a Var representing the desired value */
 		var = makeVar(parsetree->resultRelation,
 			attrno,


### PR DESCRIPTION
Fix warning redis_fdw.c:3504:3: warning: ISO C90 forbids mixed declarations and code [-Wdeclaration-after-statement]
   TargetEntry *tle;
