### PR TITLE
fix UPDATE/DELETE operations with function calls

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -19,3 +19,7 @@
 2023-08-26 Version 1.0.6
 
 - PostrgeSQL 15 support
+
+2024-01-15 Version 1.0.7
+
+- Fix error with UPDATE/DELETE operations with function calls

--- a/redis_fdw--1.0.6--1.0.7.sql
+++ b/redis_fdw--1.0.6--1.0.7.sql
@@ -1,0 +1,9 @@
+CREATE OR REPLACE FUNCTION redis_fdw_handler()
+  RETURNS fdw_handler
+  AS 'MODULE_PATHNAME'
+  LANGUAGE C STRICT;
+
+CREATE OR REPLACE FUNCTION redis_fdw_validator(text[], oid)
+  RETURNS void
+  AS 'MODULE_PATHNAME'
+  LANGUAGE C STRICT;

--- a/redis_fdw--1.0.7.sql
+++ b/redis_fdw--1.0.7.sql
@@ -1,0 +1,13 @@
+CREATE FUNCTION redis_fdw_handler()
+  RETURNS fdw_handler
+  AS 'MODULE_PATHNAME'
+  LANGUAGE C STRICT;
+
+CREATE FUNCTION redis_fdw_validator(text[], oid)
+  RETURNS void
+  AS 'MODULE_PATHNAME'
+  LANGUAGE C STRICT;
+
+CREATE FOREIGN DATA WRAPPER redis_fdw
+  HANDLER redis_fdw_handler
+  VALIDATOR redis_fdw_validator;

--- a/redis_fdw.c
+++ b/redis_fdw.c
@@ -3537,7 +3537,7 @@ redisAddForeignUpdateTargets(
 			att->attcollation,
 			0);
 
-		add_row_identity_var(root, var, rtindex, NameStr(att->attname));
+		add_row_identity_var(root, var, rtindex, colname);
 #endif
 	}
 }
@@ -4405,7 +4405,7 @@ redisExecForeignUpdate(EState *estate,
 	MemoryContextReset(rctx->temp_ctx);
 
 	/*
-	 * Get resjunk columns which are the paramters provided for the
+	 * Get resjunk columns which are the parameters provided for the
 	 * WHERE clause (from IterateForeignScan results)
 	 */
 	redis_get_resjunks(rctx, planSlot, &resjunk);

--- a/redis_fdw.control
+++ b/redis_fdw.control
@@ -1,5 +1,5 @@
 comment = 'foreign-data wrapper for Redis'
-default_version = '1.0.6'
+default_version = '1.0.7'
 module_pathname = '$libdir/redis_fdw'
 relocatable = true
 

--- a/rw_redis_fdw.spec
+++ b/rw_redis_fdw.spec
@@ -1,4 +1,4 @@
-%define redis_fdw_ver   1.0.6
+%define redis_fdw_ver   1.0.7
 %define postgresql_ver  11
 
 Summary:        Redis FDW for PostgreSQL %{postgresql_ver}
@@ -9,7 +9,7 @@ License:        PostgreSQL
 URL:            https://github.com/pg-redis-fdw/redis_fdw
 Vendor:         YASP Ltd, Luxms Group
 
-Source0:        https://codeload.github.com/luxms/rw_redis_fdw/tar.gz/v1.0.4#/luxms_rw_redis_fdw_%{postgresql_ver}.tar.gz
+Source0:        https://codeload.github.com/luxms/rw_redis_fdw/tar.gz/v1.0.7#/luxms_rw_redis_fdw_%{postgresql_ver}.tar.gz
 
 BuildRequires:  hiredis-devel llvm-toolset-7-clang postgresql%{postgresql_ver}-devel gcc
 Requires:       postgresql%{postgresql_ver}-server
@@ -45,6 +45,8 @@ export    PATH=/usr/pgsql-%{postgresql_ver}/bin:$PATH
 %{_prefix}/pgsql-11/share/extension/redis_fdw.control
 
 %changelog
+* Mon Jan 15 2024 p
+- Fix error with UPDATE/DELETE operations with function calls
 * Sat Aug 26 2023 p
 - PostreSQL 15 support
 * Wed Dec 07 2022 Andrei Chistyakov

--- a/sql/expected
+++ b/sql/expected
@@ -1,0 +1,328 @@
+CREATE EXTENSION
+CREATE SERVER
+CREATE USER MAPPING
+CREATE FOREIGN TABLE
+ALTER FOREIGN TABLE
+ALTER FOREIGN TABLE
+CREATE FOREIGN TABLE
+CREATE FOREIGN TABLE
+CREATE FOREIGN TABLE
+CREATE FOREIGN TABLE
+CREATE FOREIGN TABLE
+CREATE FOREIGN TABLE
+CREATE FOREIGN TABLE
+CREATE FOREIGN TABLE
+CREATE FOREIGN TABLE
+INSERT 0 1
+INSERT 0 1
+  skey  |  sval  | expiry 
+--------+--------+--------
+ strkey | strval |     -1
+(1 строка)
+
+  skey   |    sval    | expiry 
+---------+------------+--------
+ strkey2 | has-expiry |     30
+(1 строка)
+
+UPDATE 1
+  skey  |      sval      | expiry 
+--------+----------------+--------
+ strkey | updated-strval |     -1
+(1 строка)
+
+  skey   |    sval    | expiry 
+---------+------------+--------
+ strkey2 | has-expiry |     30
+(1 строка)
+
+UPDATE 1
+  skey  |      sval       | expiry 
+--------+-----------------+--------
+ strkey | updated-strval2 |     -1
+(1 строка)
+
+UPDATE 1
+  skey  |      sval       | expiry 
+--------+-----------------+--------
+ strkey | updated-strval3 |     -1
+(1 строка)
+
+INSERT 0 1
+INSERT 0 1
+INSERT 0 1
+INSERT 0 1
+ key  | field | value | expiry 
+------+-------+-------+--------
+ hkey | f1    | v1    |     10
+ hkey | f2    | v2    |     10
+ hkey | f4    | v4    |     10
+(3 строки)
+
+ key  | field | value | expiry 
+------+-------+-------+--------
+ hkey | f1    | v1    |     10
+(1 строка)
+
+ key  | field | value | expiry 
+------+-------+-------+--------
+ hkey | f4    | v4    |     10
+(1 строка)
+
+  key  | field | value | expiry 
+-------+-------+-------+--------
+ hkey2 | f2    | v2    |     10
+(1 строка)
+
+ key | field | value | expiry 
+-----+-------+-------+--------
+(0 строк)
+
+    key    | field |   value    | expiry 
+-----------+-------+------------+--------
+ rfth_hkey | f1    | v1-updated |      0
+(1 строка)
+
+UPDATE 1
+ key  | field |   value    | expiry 
+------+-------+------------+--------
+ hkey | f1    | v1-updated |     10
+ hkey | f2    | v2         |     10
+ hkey | f4    | v4         |     10
+(3 строки)
+
+ key  |   field    |       value        | expiry 
+------+------------+--------------------+--------
+ hkey | {f1,f2,f4} | {v1-updated,v2,v4} |     10
+(1 строка)
+
+ERROR:  foreign table "rft_mhash" does not allow inserts
+INSERT 0 1
+INSERT 0 1
+INSERT 0 1
+ key  | member  | expiry 
+------+---------+--------
+ skey | member4 |      0
+(1 строка)
+
+INSERT 0 1
+ key  | member  | expiry 
+------+---------+--------
+ skey | member1 |     -1
+ skey | member2 |     -1
+ skey | member3 |     -1
+ skey | member4 |     -1
+(4 строки)
+
+INSERT 0 1
+INSERT 0 1
+INSERT 0 1
+INSERT 0 1
+ key  | value | index | expiry 
+------+-------+-------+--------
+ lkey | idx0  |     0 |     -1
+ lkey | idx1  |     1 |     -1
+ lkey | idx2  |     2 |     -1
+ lkey | idx3  |     3 |     -1
+(4 строки)
+
+UPDATE 1
+ key  |    value     | index | expiry 
+------+--------------+-------+--------
+ lkey | idx0         |     0 |     -1
+ lkey | updated-idx2 |     1 |     -1
+ lkey | idx2         |     2 |     -1
+ lkey | idx3         |     3 |     -1
+(4 строки)
+
+DELETE 1
+ key  |    value     | index | expiry 
+------+--------------+-------+--------
+ lkey | idx0         |     0 |     -1
+ lkey | updated-idx2 |     1 |     -1
+ lkey | idx2         |     2 |     -1
+(3 строки)
+
+ key | value | index | expiry 
+-----+-------+-------+--------
+     |       |     0 |       
+(1 строка)
+
+DELETE 1
+ key  |    value     | index | expiry 
+------+--------------+-------+--------
+ lkey | idx0         |     0 |     -1
+ lkey | updated-idx2 |     1 |     -1
+ lkey | idx2         |     2 |     -1
+(3 строки)
+
+INSERT 0 1
+INSERT 0 1
+INSERT 0 1
+ key  | member  | score | index | expiry 
+------+---------+-------+-------+--------
+ zkey | member1 |     1 |     0 |     -1
+ zkey | member2 |     2 |     1 |     -1
+ zkey | member3 |     3 |     2 |     -1
+(3 строки)
+
+ key  | member  | score | index | expiry 
+------+---------+-------+-------+--------
+ zkey | member2 |     0 |     1 |     -1
+(1 строка)
+
+ key  | member  | score | index | expiry 
+------+---------+-------+-------+--------
+ zkey | member2 |     2 |     1 |     -1
+(1 строка)
+
+ key  | member  | score | index | expiry 
+------+---------+-------+-------+--------
+ zkey | member3 |     3 |     2 |     -1
+(1 строка)
+
+ key  | member  | score | index | expiry 
+------+---------+-------+-------+--------
+ zkey | member2 |     2 |     1 |     -1
+ zkey | member3 |     3 |     2 |     -1
+(2 строки)
+
+ key  | member  | score | index | expiry 
+------+---------+-------+-------+--------
+ zkey | member2 |     2 |     0 |     -1
+ zkey | member3 |     3 |     0 |     -1
+(2 строки)
+
+    key    | expiry 
+-----------+--------
+ rftz_zkey |     -1
+(1 строка)
+
+UPDATE 1
+    key    | expiry 
+-----------+--------
+ rftz_zkey |      3
+(1 строка)
+
+    key    | tabletype | len | expiry 
+-----------+-----------+-----+--------
+ rftz_zkey | zset      |   3 |      3
+(1 строка)
+
+ key | tabletype | len | expiry 
+-----+-----------+-----+--------
+ *   | *         |   7 |      0
+(1 строка)
+
+ channel | message | len 
+---------+---------+-----
+ chan    | message |   0
+(1 строка)
+
+INSERT 0 1
+ channel | message | len 
+---------+---------+-----
+ chan    |         |   0
+(1 строка)
+
+ERROR:  only INSERT is permitted for PUBLISH
+ERROR:  only INSERT is permitted for PUBLISH
+     key      
+--------------
+ rfth_hkey2
+ rftl_lkey
+ rfts_skey
+ rftc_strkey2
+ rftz_zkey
+ rftc_strkey
+ rfth_hkey
+(7 строк)
+
+    key    
+-----------
+ rftz_zkey
+(1 строка)
+
+DELETE 1
+ key  | field |   value    | expiry 
+------+-------+------------+--------
+ hkey | f1    | v1-updated |     10
+ hkey | f4    | v4         |     10
+(2 строки)
+
+ key | field | value | expiry 
+-----+-------+-------+--------
+(0 строк)
+
+ key  |  field  |      value      | expiry 
+------+---------+-----------------+--------
+ hkey | {f1,f4} | {v1-updated,v4} |     10
+(1 строка)
+
+DELETE 1
+ key | field | value | expiry 
+-----+-------+-------+--------
+(0 строк)
+
+DELETE 1
+ key  |    value     | index | expiry 
+------+--------------+-------+--------
+ lkey | idx0         |     0 |     -1
+ lkey | updated-idx2 |     1 |     -1
+(2 строки)
+
+DELETE 1
+ key  |    value     | index | expiry 
+------+--------------+-------+--------
+ lkey | updated-idx2 |     0 |     -1
+(1 строка)
+
+DELETE 1
+ key  | member  | expiry 
+------+---------+--------
+ skey | member1 |     -1
+ skey | member3 |     -1
+ skey | member4 |     -1
+(3 строки)
+
+ key  | member  | expiry 
+------+---------+--------
+ skey | member3 |     -1
+(1 строка)
+
+DELETE 1
+ key  | member  | score | index | expiry 
+------+---------+-------+-------+--------
+ zkey | member1 |     1 |     0 |      3
+ zkey | member2 |     2 |     1 |      3
+(2 строки)
+
+DELETE 1
+DELETE 1
+DELETE 1
+DELETE 1
+DELETE 1
+ key | value | index | expiry 
+-----+-------+-------+--------
+(0 строк)
+
+DELETE 1
+ key | member | score | index | expiry 
+-----+--------+-------+-------+--------
+(0 строк)
+
+    key    
+-----------
+ rfts_skey
+(1 строка)
+
+DROP FOREIGN TABLE
+DROP FOREIGN TABLE
+DROP FOREIGN TABLE
+DROP FOREIGN TABLE
+DROP FOREIGN TABLE
+DROP FOREIGN TABLE
+DROP FOREIGN TABLE
+DROP FOREIGN TABLE
+DROP FOREIGN TABLE
+DROP FOREIGN TABLE


### PR DESCRIPTION
https://github.com/luxms/rw_redis_fdw/commit/f94c101f3ca859f0854f9eb163493b0edde5ab90#diff-7f0cc38c5bd36866d7202ea65ca33ceda719949c9822a164b343471a759e56baR3525

Adapted code to newer callback signature (pg14 and above), but broke `UPDATE/DELETE` operations if there was a function call inside `WHERE` for tables with renamed columns. For these tables, column `key` (if renamed) was stored with the real column name, resulting in a `key not provided` error.

This pull request fixes the above issue, adds renaming of the `key` column in `sql/redis_fdw.sql` and `UPDATE/DELETE` operations with a `format(TEXT,TEXT)` call. Also adds missing expected output, to compare against.