### PR TITLE
Key is null error

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -27,3 +27,9 @@
 2024-06-10 Version 1.0.8
 
 - Fix Makefile to override PG_CONFIG variables
+
+2024-07-22 Version 1.0.9
+
+- Fix key is NULL error
+- Add new test cases
+- Fix 1.0.8 update script

--- a/redis_fdw--1.0.7--1.0.8.sql
+++ b/redis_fdw--1.0.7--1.0.8.sql
@@ -6,3 +6,4 @@ CREATE OR REPLACE FUNCTION redis_fdw_handler()
 CREATE OR REPLACE FUNCTION redis_fdw_validator(text[], oid)
   RETURNS void
   AS 'MODULE_PATHNAME'
+  LANGUAGE C STRICT;

--- a/redis_fdw--1.0.8--1.0.9.sql
+++ b/redis_fdw--1.0.8--1.0.9.sql
@@ -1,0 +1,9 @@
+CREATE OR REPLACE FUNCTION redis_fdw_handler()
+  RETURNS fdw_handler
+  AS 'MODULE_PATHNAME'
+  LANGUAGE C STRICT;
+
+CREATE OR REPLACE FUNCTION redis_fdw_validator(text[], oid)
+  RETURNS void
+  AS 'MODULE_PATHNAME'
+  LANGUAGE C STRICT;

--- a/redis_fdw--1.0.9.sql
+++ b/redis_fdw--1.0.9.sql
@@ -1,0 +1,13 @@
+CREATE FUNCTION redis_fdw_handler()
+  RETURNS fdw_handler
+  AS 'MODULE_PATHNAME'
+  LANGUAGE C STRICT;
+
+CREATE FUNCTION redis_fdw_validator(text[], oid)
+  RETURNS void
+  AS 'MODULE_PATHNAME'
+  LANGUAGE C STRICT;
+
+CREATE FOREIGN DATA WRAPPER redis_fdw
+  HANDLER redis_fdw_handler
+  VALIDATOR redis_fdw_validator;

--- a/redis_fdw.c
+++ b/redis_fdw.c
@@ -1908,7 +1908,7 @@ redis_parse_where(struct redis_fdw_ctx *rctx, RelOptInfo *foreignrel,
 
 
 			if (subexpr->type == T_Param || subexpr->type == T_RelabelType ||
-			    subexpr->type == T_FuncExpr) {
+			    subexpr->type == T_FuncExpr || subexpr->type == T_OpExpr) {
 				struct redis_param_desc *pd;
 
 				param = (Param *)subexpr;

--- a/redis_fdw.c
+++ b/redis_fdw.c
@@ -1888,7 +1888,7 @@ redis_parse_where(struct redis_fdw_ctx *rctx, RelOptInfo *foreignrel,
 					rctx->where_flags |= PARAM_VALUE;
 					break;
 				}
-				/* fall through for other table types */
+				/* falls through */
 			default:
 				/*
 				DEBUG((DEBUG_LEVEL, "unhandled left index: %d", leftidx));

--- a/redis_fdw.c
+++ b/redis_fdw.c
@@ -72,7 +72,7 @@
 
 #if PG_VERSION_NUM >= 140000
 #include "optimizer/appendinfo.h"
-#endif 
+#endif
 
 #if PG_VERSION_NUM < 120000
 #include "optimizer/var.h"
@@ -129,11 +129,11 @@ PG_MODULE_MAGIC;
 #define DEBUG_LEVEL INFO
 
 
-/* Possible crashes if you call elog at the end of the macro. 
- * Often you want to print reply fields with ERR_CLEANUP, 
+/* Possible crashes if you call elog at the end of the macro.
+ * Often you want to print reply fields with ERR_CLEANUP,
  * but reply was set to NULL early in this macro :-(
  * For example:
- * 			    ERR_CLEANUP(rctx->r_reply, rctx->r_ctx, 
+ * 			    ERR_CLEANUP(rctx->r_reply, rctx->r_ctx,
  *				    (ERROR, "redis error: %s", rctx->r_reply->str));
  */
 #define ERR_CLEANUP(reply,conn,eparams)	do { 			\
@@ -189,7 +189,7 @@ static void redisEndForeignScan(ForeignScanState *node);
 		RangeTblEntry *target_rte,
 		Relation target_relation);
 #else
-	static void redisAddForeignUpdateTargets(PlannerInfo *root, 
+	static void redisAddForeignUpdateTargets(PlannerInfo *root,
 		Index rtindex,
 		RangeTblEntry *target_rte,
 		Relation target_relation);
@@ -1179,7 +1179,7 @@ redis_fdw_validator(PG_FUNCTION_ARGS)
 			ereport(ERROR,
 			       (errcode(ERRCODE_FDW_INVALID_OPTION_NAME),
 			        errmsg("invalid option \"%s\"", def->defname),
-			        errhint("Valid options in this context are: %s", 
+			        errhint("Valid options in this context are: %s",
 			                buf.len ? buf.data : "<none>")
 			        ));
 		}
@@ -1198,7 +1198,7 @@ redis_fdw_validator(PG_FUNCTION_ARGS)
 			if (port > 0)
 				ereport(ERROR,
 				        (errcode(ERRCODE_SYNTAX_ERROR),
-				         errmsg("conflicting or redundant options: %s (%s)", 
+				         errmsg("conflicting or redundant options: %s (%s)",
 				                OPT_PORT, defGetString(def))
 				        ));
 
@@ -1206,7 +1206,7 @@ redis_fdw_validator(PG_FUNCTION_ARGS)
 			if (port <= 0)
 				ereport(ERROR,
 				        (errcode(ERRCODE_SYNTAX_ERROR),
-				         errmsg("invalid value: %s (%s)", 
+				         errmsg("invalid value: %s (%s)",
 				                OPT_PORT, defGetString(def))
 				        ));
 		} else if (strcmp(def->defname, OPT_PASSWORD) == 0) {
@@ -1753,7 +1753,7 @@ redis_get_var(struct redis_fdw_ctx *rctx, RelOptInfo *foreignrel, Var *var)
 		if (rtable->expiry == var->varattno)
 			return VAR_EXPIRY;
 		if (rtable->valttl == var->varattno)
-			return VAR_VALTTL;			
+			return VAR_VALTTL;
 		if (rtable->index == var->varattno)
 			return VAR_INDEX;
 		if (rtable->score == var->varattno)
@@ -2253,7 +2253,7 @@ redisGetForeignRelSize(PlannerInfo *root,
 		else
 			reply = redisCommand(ctx, "DBSIZE");
 		break;
-	
+
 	case PG_REDIS_SET:
 		if (rctx->pfxkey != NULL)
 			reply = redisCommand(ctx, "SCARD %s", rctx->pfxkey);
@@ -3014,7 +3014,7 @@ redisIterateForeignScan(ForeignScanState *node)
 				rctx->rowcount = 0;
 				break;
 			default:
-			    ERR_CLEANUP(rctx->r_reply, rctx->r_ctx, 
+			    ERR_CLEANUP(rctx->r_reply, rctx->r_ctx,
 				    (ERROR, "redis error: %s", rctx->r_reply->str));
 			}
 
@@ -3114,7 +3114,7 @@ redisIterateForeignScan(ForeignScanState *node)
 
 		reply = rctx->r_reply->element[rctx->rowsdone++];
 		redis_get_reply(reply, &s_value, &i_value, &nil_value);
-		
+
 		reply = rctx->r_reply->element[rctx->rowsdone++];
 		redis_get_reply(reply, &s_score, &score, &nil_value);
 		rctx->rowcount -= 2;
@@ -3134,7 +3134,7 @@ redisIterateForeignScan(ForeignScanState *node)
 
 			reply = rctx->r_reply->element[rctx->rowsdone++];
 			field = reply->str;
-		
+
 			reply = rctx->r_reply->element[rctx->rowsdone++];
 			redis_get_reply(reply, &s_value, &i_value, &nil_value);
 			rctx->rowcount -= 2;
@@ -3388,7 +3388,7 @@ redisAddForeignUpdateTargets(
 		DefElem *def = (DefElem *) lfirst(option);
 		char *v;
 
-		redis_opt_string(def, OPT_TABLETYPE, &v);	
+		redis_opt_string(def, OPT_TABLETYPE, &v);
 		if (v != NULL) {
 			table_type = redis_str_to_tabletype(v);
 			if (table_type == PG_REDIS_INVALID)
@@ -3431,7 +3431,7 @@ redisAddForeignUpdateTargets(
 		Form_pg_attribute att = &tupdesc->attrs[i];
 #endif
 		AttrNumber attrno = att->attnum;
-		Var *var;		
+		Var *var;
 		char *colname;
 		int   colkey;
 		bool  skip;
@@ -3495,12 +3495,12 @@ redisAddForeignUpdateTargets(
 			break;
 		case PG_REDIS_LIST:
 			if (colkey & ~(PARAM_KEY | PARAM_INDEX | PARAM_VALUE))
-				skip = true;	
+				skip = true;
 			break;
 		case PG_REDIS_SET:
 		case PG_REDIS_ZSET:
 			if (colkey & ~(PARAM_KEY | PARAM_MEMBER))
-				skip = true;	
+				skip = true;
 			break;
 		default:
 			/* shouldn't get here */
@@ -3511,7 +3511,7 @@ redisAddForeignUpdateTargets(
 		if (skip)
 			continue;
 
-#if PG_VERSION_NUM < 140000		
+#if PG_VERSION_NUM < 140000
 		/*TargetEntry *tle;*/
 		/* make a Var representing the desired value */
 		var = makeVar(parsetree->resultRelation,
@@ -4000,7 +4000,7 @@ redisExecForeignInsert(EState *estate,
 					ERR_CLEANUP(rctx->r_reply, rctx->r_ctx,
 					    (ERROR, "invalid value for valttl %s", param->value));
 			}
-			break;			
+			break;
 		case VAR_MESSAGE:
 			if (isnull)
 				ERR_CLEANUP(rctx->r_reply, rctx->r_ctx,
@@ -4187,7 +4187,7 @@ redisExecForeignInsert(EState *estate,
 		}
 
 		if (expreply == NULL) {
-			
+
 			ereport(ERROR,
 			   (errcode(ERRCODE_FDW_ERROR),
 			    errmsg("EXPIREMEMBER reply NULL %d %s", rctx->r_ctx->err, rctx->r_ctx->errstr)));
@@ -4306,7 +4306,7 @@ redis_get_resjunks(struct redis_fdw_ctx *rctx, TupleTableSlot *planSlot,
 		if (!isnull) {
 			rj->hasval |= PARAM_KEY;
 			rj->key = DatumGetCString(OidFunctionCall1(
-		             rctx->rtable.columns[rctx->rtable.key-1].typoutput, 
+		             rctx->rtable.columns[rctx->rtable.key-1].typoutput,
 		             datum));
 			DEBUG((DEBUG_LEVEL, "update/delete WHERE key = %s", rj->key));
 		}
@@ -4317,7 +4317,7 @@ redis_get_resjunks(struct redis_fdw_ctx *rctx, TupleTableSlot *planSlot,
 		if (!isnull) {
 			rj->hasval |= PARAM_FIELD;
 			rj->field = DatumGetCString(OidFunctionCall1(
-		               rctx->rtable.columns[rctx->rtable.field-1].typoutput, 
+		               rctx->rtable.columns[rctx->rtable.field-1].typoutput,
 		               datum));
 			DEBUG((DEBUG_LEVEL, "update/delete WHERE field = %s", rj->field));
 		}
@@ -4329,7 +4329,7 @@ redis_get_resjunks(struct redis_fdw_ctx *rctx, TupleTableSlot *planSlot,
 		if (!isnull) {
 			rj->hasval |= PARAM_INDEX;
 			s = DatumGetCString(OidFunctionCall1(
-		               rctx->rtable.columns[rctx->rtable.index-1].typoutput, 
+		               rctx->rtable.columns[rctx->rtable.index-1].typoutput,
 		               datum));
 			rj->index = atoll(s);
 			DEBUG((DEBUG_LEVEL, "update/delete WHERE index = %" PRId64 " [%s]",
@@ -4342,7 +4342,7 @@ redis_get_resjunks(struct redis_fdw_ctx *rctx, TupleTableSlot *planSlot,
 		if (!isnull) {
 			rj->hasval |= PARAM_MEMBER;
 			rj->member = DatumGetCString(OidFunctionCall1(
-		               rctx->rtable.columns[rctx->rtable.member-1].typoutput, 
+		               rctx->rtable.columns[rctx->rtable.member-1].typoutput,
 		               datum));
 			DEBUG((DEBUG_LEVEL, "update/delete WHERE member = %s", rj->member));
 		}
@@ -4353,7 +4353,7 @@ redis_get_resjunks(struct redis_fdw_ctx *rctx, TupleTableSlot *planSlot,
 		if (!isnull) {
 			rj->hasval |= PARAM_VALUE;
 			rj->member = DatumGetCString(OidFunctionCall1(
-		               rctx->rtable.columns[rctx->rtable.s_value-1].typoutput, 
+		               rctx->rtable.columns[rctx->rtable.s_value-1].typoutput,
 		               datum));
 			DEBUG((DEBUG_LEVEL, "update/delete WHERE value = %s", rj->member));
 		}

--- a/redis_fdw.control
+++ b/redis_fdw.control
@@ -1,5 +1,5 @@
 comment = 'foreign-data wrapper for Redis'
-default_version = '1.0.8'
+default_version = '1.0.9'
 module_pathname = '$libdir/redis_fdw'
 relocatable = true
 

--- a/rw_redis_fdw.spec
+++ b/rw_redis_fdw.spec
@@ -1,4 +1,4 @@
-%define redis_fdw_ver   1.0.7
+%define redis_fdw_ver   1.0.9
 %define postgresql_ver  11
 
 Summary:        Redis FDW for PostgreSQL %{postgresql_ver}
@@ -9,7 +9,7 @@ License:        PostgreSQL
 URL:            https://github.com/pg-redis-fdw/redis_fdw
 Vendor:         YASP Ltd, Luxms Group
 
-Source0:        https://codeload.github.com/luxms/rw_redis_fdw/tar.gz/v1.0.7#/luxms_rw_redis_fdw_%{postgresql_ver}.tar.gz
+Source0:        https://codeload.github.com/luxms/rw_redis_fdw/tar.gz/v1.0.9#/luxms_rw_redis_fdw_%{postgresql_ver}.tar.gz
 
 BuildRequires:  hiredis-devel llvm-toolset-7-clang postgresql%{postgresql_ver}-devel gcc
 Requires:       postgresql%{postgresql_ver}-server
@@ -45,6 +45,8 @@ export    PATH=/usr/pgsql-%{postgresql_ver}/bin:$PATH
 %{_prefix}/pgsql-11/share/extension/redis_fdw.control
 
 %changelog
+* Mon Jul 22 2024 p
+- Fix formatting, fix key is NULL error, fix previous release
 * Mon Jan 15 2024 p
 - Fix error with UPDATE/DELETE operations with function calls
 * Sat Aug 26 2023 p

--- a/sql/expected
+++ b/sql/expected
@@ -297,6 +297,20 @@ DELETE 1
  zkey | member2 |     2 |     1 |      3
 (2 rows)
 
+CREATE FUNCTION
+CREATE FUNCTION
+ where_clause_func_expr | where_clause_func_expr | where_clause_func_expr | where_clause_func_expr | where_clause_func_expr | where_clause_func_expr 
+------------------------+------------------------+------------------------+------------------------+------------------------+------------------------
+ updated-strval3        | updated-strval3        | updated-strval3        | updated-strval3        | updated-strval3        | updated-strval3
+(1 row)
+
+ where_clause_op_expr | where_clause_op_expr | where_clause_op_expr | where_clause_op_expr | where_clause_op_expr | where_clause_op_expr 
+----------------------+----------------------+----------------------+----------------------+----------------------+----------------------
+ updated-strval3      | updated-strval3      | updated-strval3      | updated-strval3      | updated-strval3      | updated-strval3
+(1 row)
+
+DROP FUNCTION
+DROP FUNCTION
 DELETE 1
 DELETE 1
 DELETE 1

--- a/sql/expected
+++ b/sql/expected
@@ -18,35 +18,35 @@ INSERT 0 1
   skey  |  sval  | expiry 
 --------+--------+--------
  strkey | strval |     -1
-(1 строка)
+(1 row)
 
   skey   |    sval    | expiry 
 ---------+------------+--------
  strkey2 | has-expiry |     30
-(1 строка)
+(1 row)
 
 UPDATE 1
   skey  |      sval      | expiry 
 --------+----------------+--------
  strkey | updated-strval |     -1
-(1 строка)
+(1 row)
 
   skey   |    sval    | expiry 
 ---------+------------+--------
  strkey2 | has-expiry |     30
-(1 строка)
+(1 row)
 
 UPDATE 1
   skey  |      sval       | expiry 
 --------+-----------------+--------
  strkey | updated-strval2 |     -1
-(1 строка)
+(1 row)
 
 UPDATE 1
   skey  |      sval       | expiry 
 --------+-----------------+--------
  strkey | updated-strval3 |     -1
-(1 строка)
+(1 row)
 
 INSERT 0 1
 INSERT 0 1
@@ -57,31 +57,31 @@ INSERT 0 1
  hkey | f1    | v1    |     10
  hkey | f2    | v2    |     10
  hkey | f4    | v4    |     10
-(3 строки)
+(3 rows)
 
  key  | field | value | expiry 
 ------+-------+-------+--------
  hkey | f1    | v1    |     10
-(1 строка)
+(1 row)
 
  key  | field | value | expiry 
 ------+-------+-------+--------
  hkey | f4    | v4    |     10
-(1 строка)
+(1 row)
 
   key  | field | value | expiry 
 -------+-------+-------+--------
  hkey2 | f2    | v2    |     10
-(1 строка)
+(1 row)
 
  key | field | value | expiry 
 -----+-------+-------+--------
-(0 строк)
+(0 rows)
 
     key    | field |   value    | expiry 
 -----------+-------+------------+--------
  rfth_hkey | f1    | v1-updated |      0
-(1 строка)
+(1 row)
 
 UPDATE 1
  key  | field |   value    | expiry 
@@ -89,12 +89,12 @@ UPDATE 1
  hkey | f1    | v1-updated |     10
  hkey | f2    | v2         |     10
  hkey | f4    | v4         |     10
-(3 строки)
+(3 rows)
 
  key  |   field    |       value        | expiry 
 ------+------------+--------------------+--------
  hkey | {f1,f2,f4} | {v1-updated,v2,v4} |     10
-(1 строка)
+(1 row)
 
 ERROR:  foreign table "rft_mhash" does not allow inserts
 INSERT 0 1
@@ -103,7 +103,7 @@ INSERT 0 1
  key  | member  | expiry 
 ------+---------+--------
  skey | member4 |      0
-(1 строка)
+(1 row)
 
 INSERT 0 1
  key  | member  | expiry 
@@ -112,7 +112,7 @@ INSERT 0 1
  skey | member2 |     -1
  skey | member3 |     -1
  skey | member4 |     -1
-(4 строки)
+(4 rows)
 
 INSERT 0 1
 INSERT 0 1
@@ -124,7 +124,7 @@ INSERT 0 1
  lkey | idx1  |     1 |     -1
  lkey | idx2  |     2 |     -1
  lkey | idx3  |     3 |     -1
-(4 строки)
+(4 rows)
 
 UPDATE 1
  key  |    value     | index | expiry 
@@ -133,7 +133,7 @@ UPDATE 1
  lkey | updated-idx2 |     1 |     -1
  lkey | idx2         |     2 |     -1
  lkey | idx3         |     3 |     -1
-(4 строки)
+(4 rows)
 
 DELETE 1
  key  |    value     | index | expiry 
@@ -141,12 +141,12 @@ DELETE 1
  lkey | idx0         |     0 |     -1
  lkey | updated-idx2 |     1 |     -1
  lkey | idx2         |     2 |     -1
-(3 строки)
+(3 rows)
 
  key | value | index | expiry 
 -----+-------+-------+--------
      |       |     0 |       
-(1 строка)
+(1 row)
 
 DELETE 1
  key  |    value     | index | expiry 
@@ -154,7 +154,7 @@ DELETE 1
  lkey | idx0         |     0 |     -1
  lkey | updated-idx2 |     1 |     -1
  lkey | idx2         |     2 |     -1
-(3 строки)
+(3 rows)
 
 INSERT 0 1
 INSERT 0 1
@@ -164,118 +164,118 @@ INSERT 0 1
  zkey | member1 |     1 |     0 |     -1
  zkey | member2 |     2 |     1 |     -1
  zkey | member3 |     3 |     2 |     -1
-(3 строки)
+(3 rows)
 
  key  | member  | score | index | expiry 
 ------+---------+-------+-------+--------
  zkey | member2 |     0 |     1 |     -1
-(1 строка)
+(1 row)
 
  key  | member  | score | index | expiry 
 ------+---------+-------+-------+--------
  zkey | member2 |     2 |     1 |     -1
-(1 строка)
+(1 row)
 
  key  | member  | score | index | expiry 
 ------+---------+-------+-------+--------
  zkey | member3 |     3 |     2 |     -1
-(1 строка)
+(1 row)
 
  key  | member  | score | index | expiry 
 ------+---------+-------+-------+--------
  zkey | member2 |     2 |     1 |     -1
  zkey | member3 |     3 |     2 |     -1
-(2 строки)
+(2 rows)
 
  key  | member  | score | index | expiry 
 ------+---------+-------+-------+--------
  zkey | member2 |     2 |     0 |     -1
  zkey | member3 |     3 |     0 |     -1
-(2 строки)
+(2 rows)
 
     key    | expiry 
 -----------+--------
  rftz_zkey |     -1
-(1 строка)
+(1 row)
 
 UPDATE 1
     key    | expiry 
 -----------+--------
  rftz_zkey |      3
-(1 строка)
+(1 row)
 
     key    | tabletype | len | expiry 
 -----------+-----------+-----+--------
  rftz_zkey | zset      |   3 |      3
-(1 строка)
+(1 row)
 
  key | tabletype | len | expiry 
 -----+-----------+-----+--------
  *   | *         |   7 |      0
-(1 строка)
+(1 row)
 
  channel | message | len 
 ---------+---------+-----
  chan    | message |   0
-(1 строка)
+(1 row)
 
 INSERT 0 1
  channel | message | len 
 ---------+---------+-----
  chan    |         |   0
-(1 строка)
+(1 row)
 
 ERROR:  only INSERT is permitted for PUBLISH
 ERROR:  only INSERT is permitted for PUBLISH
      key      
 --------------
+ rftc_strkey
+ rftc_strkey2
+ rfth_hkey
  rfth_hkey2
  rftl_lkey
  rfts_skey
- rftc_strkey2
  rftz_zkey
- rftc_strkey
- rfth_hkey
-(7 строк)
+(7 rows)
 
     key    
 -----------
  rftz_zkey
-(1 строка)
+(1 row)
 
 DELETE 1
  key  | field |   value    | expiry 
 ------+-------+------------+--------
  hkey | f1    | v1-updated |     10
  hkey | f4    | v4         |     10
-(2 строки)
+(2 rows)
 
  key | field | value | expiry 
 -----+-------+-------+--------
-(0 строк)
+(0 rows)
 
  key  |  field  |      value      | expiry 
 ------+---------+-----------------+--------
  hkey | {f1,f4} | {v1-updated,v4} |     10
-(1 строка)
+(1 row)
 
 DELETE 1
  key | field | value | expiry 
 -----+-------+-------+--------
-(0 строк)
+(0 rows)
 
 DELETE 1
  key  |    value     | index | expiry 
 ------+--------------+-------+--------
  lkey | idx0         |     0 |     -1
  lkey | updated-idx2 |     1 |     -1
-(2 строки)
+(2 rows)
 
 DELETE 1
  key  |    value     | index | expiry 
 ------+--------------+-------+--------
  lkey | updated-idx2 |     0 |     -1
-(1 строка)
+(1 row)
 
 DELETE 1
  key  | member  | expiry 
@@ -283,19 +283,19 @@ DELETE 1
  skey | member1 |     -1
  skey | member3 |     -1
  skey | member4 |     -1
-(3 строки)
+(3 rows)
 
  key  | member  | expiry 
 ------+---------+--------
  skey | member3 |     -1
-(1 строка)
+(1 row)
 
 DELETE 1
  key  | member  | score | index | expiry 
 ------+---------+-------+-------+--------
  zkey | member1 |     1 |     0 |      3
  zkey | member2 |     2 |     1 |      3
-(2 строки)
+(2 rows)
 
 DELETE 1
 DELETE 1
@@ -304,17 +304,17 @@ DELETE 1
 DELETE 1
  key | value | index | expiry 
 -----+-------+-------+--------
-(0 строк)
+(0 rows)
 
 DELETE 1
  key | member | score | index | expiry 
 -----+--------+-------+-------+--------
-(0 строк)
+(0 rows)
 
     key    
 -----------
  rfts_skey
-(1 строка)
+(1 row)
 
 DROP FOREIGN TABLE
 DROP FOREIGN TABLE

--- a/sql/redis_fdw.sql
+++ b/sql/redis_fdw.sql
@@ -210,7 +210,7 @@ UPDATE rft_pub SET message = 'something' WHERE channel = 'chan';
 DELETE FROM rft_pub WHERE channel = 'chan';
 
 -- list keys
-SELECT * FROM rft_keys;
+SELECT * FROM rft_keys ORDER BY key;
 
 -- list keys with pattern
 SELECT * FROM rft_keys WHERE key = 'rftz*';


### PR DESCRIPTION
remove repo changes that were mistakenly merged in #12, leave all other changes plus fix error in latest release

* add T_OpExpr to condition to fix missing key in a functions with a where clause that have operation
* added two test cases that call two new functions 6 times to check that no error occurred
* code cleanup: remove trailing spaces from redis_fdw.c and remove localization from expected
* fix -Wimplicit-fallthrough warning
* fix mistake in 1.0.8 upgrade script