### PR TITLE
fix issues related to --enable-cassert, address memory issues on redis error checks

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -33,3 +33,8 @@
 - Fix key is NULL error
 - Add new test cases
 - Fix 1.0.8 update script
+
+2024-10-07 Version 1.0.10
+
+- Fix errors running on server built with --enable-cassert
+- Fix memory issues on error handling

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,3 @@
-
 MODULE_big = redis_fdw
 OBJS = redis_fdw.o
 
@@ -8,12 +7,11 @@ DATA = $(wildcard redis_fdw--*.sql)
 SHLIB_LINK += -lhiredis
 
 PG_CONFIG = pg_config
-PG_CPPFLAGS+= -DWRITE_API
+PG_CFLAGS += -DWRITE_API -Werror
 
 ifdef DEBUG
-PG_CPPFLAGS+= -DDO_DEBUG -g
+PG_CFLAGS += -DDO_DEBUG -O0 -g
 endif
 
 PGXS := $(shell $(PG_CONFIG) --pgxs)
 include $(PGXS)
-

--- a/redis_fdw--1.0.10.sql
+++ b/redis_fdw--1.0.10.sql
@@ -1,0 +1,13 @@
+CREATE FUNCTION redis_fdw_handler()
+  RETURNS fdw_handler
+  AS 'MODULE_PATHNAME'
+  LANGUAGE C STRICT;
+
+CREATE FUNCTION redis_fdw_validator(text[], oid)
+  RETURNS void
+  AS 'MODULE_PATHNAME'
+  LANGUAGE C STRICT;
+
+CREATE FOREIGN DATA WRAPPER redis_fdw
+  HANDLER redis_fdw_handler
+  VALIDATOR redis_fdw_validator;

--- a/redis_fdw--1.0.9--1.0.10.sql
+++ b/redis_fdw--1.0.9--1.0.10.sql
@@ -1,0 +1,9 @@
+CREATE OR REPLACE FUNCTION redis_fdw_handler()
+  RETURNS fdw_handler
+  AS 'MODULE_PATHNAME'
+  LANGUAGE C STRICT;
+
+CREATE OR REPLACE FUNCTION redis_fdw_validator(text[], oid)
+  RETURNS void
+  AS 'MODULE_PATHNAME'
+  LANGUAGE C STRICT;

--- a/redis_fdw.c
+++ b/redis_fdw.c
@@ -316,7 +316,7 @@ enum redis_data_type {
 #define PARAM_TABLE_TYPE   0x0200
 #define PARAM_CHANNEL      0x0400
 #define PARAM_MESSAGE      0x0800
-#define PARAM_VALTTL    0x1000
+#define PARAM_VALTTL       0x1000
 
 /*
  * column names/ids that this module accepts
@@ -956,7 +956,6 @@ redis_serialize_fdw(struct redis_fdw_ctx *rctx)
 
 	for (param = rctx->params; param != NULL; param = param->next) {
 		/* keep paramid which is the location of the parameter */
-		Assert(param->param != NULL);
 		result = lappend(result, serializeInt32(param->paramid));
 		result = lappend(result, serializeInt32(param->var_field));
 		result = lappend(result, serializeInt32(param->op));
@@ -3696,6 +3695,7 @@ redisPlanForeignModify(PlannerInfo *root,
 				break;
 			case VAR_MESSAGE:
 				rctx->param_flags |= PARAM_MESSAGE;
+				break;
 			default:
 				DEBUG((DEBUG_LEVEL, "skipping parameter"));
 				break;

--- a/redis_fdw.c
+++ b/redis_fdw.c
@@ -3071,7 +3071,7 @@ redisIterateForeignScan(ForeignScanState *node)
 	old_ctx = MemoryContextSwitchTo(rctx->temp_ctx);
 	ExecClearTuple(slot);
 
-	if (rctx->rowcount <= 0 || rctx->cmd == REDIS_DISCARD_RESULT) {
+	if (rctx->rowcount == 0 || rctx->cmd == REDIS_DISCARD_RESULT) {
 		if (rctx->r_reply != NULL) {
 			freeReplyObject(rctx->r_reply);
 			rctx->r_reply = NULL;

--- a/redis_fdw.c
+++ b/redis_fdw.c
@@ -1879,7 +1879,7 @@ redis_parse_where(struct redis_fdw_ctx *rctx, RelOptInfo *foreignrel,
 					rctx->where_flags |= PARAM_VALUE;
 					break;
 				}
-				/* falls through */
+				/* fall-through */
 			default:
 				/*
 				DEBUG((DEBUG_LEVEL, "unhandled left index: %d", leftidx));

--- a/redis_fdw.control
+++ b/redis_fdw.control
@@ -1,5 +1,4 @@
 comment = 'foreign-data wrapper for Redis'
-default_version = '1.0.9'
+default_version = '1.0.10'
 module_pathname = '$libdir/redis_fdw'
 relocatable = true
-

--- a/rw_redis_fdw.spec
+++ b/rw_redis_fdw.spec
@@ -1,4 +1,4 @@
-%define redis_fdw_ver   1.0.9
+%define redis_fdw_ver   1.0.10
 %define postgresql_ver  11
 
 Summary:        Redis FDW for PostgreSQL %{postgresql_ver}
@@ -9,7 +9,7 @@ License:        PostgreSQL
 URL:            https://github.com/pg-redis-fdw/redis_fdw
 Vendor:         YASP Ltd, Luxms Group
 
-Source0:        https://codeload.github.com/luxms/rw_redis_fdw/tar.gz/v1.0.9#/luxms_rw_redis_fdw_%{postgresql_ver}.tar.gz
+Source0:        https://codeload.github.com/luxms/rw_redis_fdw/tar.gz/v1.0.10#/luxms_rw_redis_fdw_%{postgresql_ver}.tar.gz
 
 BuildRequires:  hiredis-devel llvm-toolset-7-clang postgresql%{postgresql_ver}-devel gcc
 Requires:       postgresql%{postgresql_ver}-server
@@ -45,6 +45,8 @@ export    PATH=/usr/pgsql-%{postgresql_ver}/bin:$PATH
 %{_prefix}/pgsql-11/share/extension/redis_fdw.control
 
 %changelog
+* Mon Oct 07 2024 p
+- Fix errors running with --enable-cassert, fix memory issues on error handling
 * Mon Jul 22 2024 p
 - Fix formatting, fix key is NULL error, fix previous release
 * Mon Jan 15 2024 p


### PR DESCRIPTION
Closes #17, #18

* Assert from #17 seems to be incorrect, most of the time param field contains NULL, this leads to immediate crash on any INSERT attempt with `--enable-cassert`
* for some reason compiler never complained about implicit fallthrough, but it seems like an error, since parameter is not actually skipped
* fix formatting
* read stashed value on every `redisIterateForeignScan` call, previously it was done on the first call which lead to issue described in #18, on second invocation with `--enable-cassert` key can be wiped out
* remove redundant `NULL` check inside redis_get_reply, variable dereferenced before that
* attempt to fix memory issues on Redis error checks