### PR TITLE
redis_fdw.c: fix error

### DIFF
--- a/redis_fdw.c
+++ b/redis_fdw.c
@@ -3032,6 +3032,8 @@ redisIterateForeignScan(ForeignScanState *node)
 		}
 
 		if (rctx->r_reply != NULL) {
+			char *msg;
+
 			switch (rctx->r_reply->type) {
 			case REDIS_REPLY_INTEGER:
 			case REDIS_REPLY_STRING:
@@ -3050,7 +3052,7 @@ redisIterateForeignScan(ForeignScanState *node)
 				rctx->rowcount = 0;
 				break;
 			default:
-				char *msg = pstrdup(rctx->r_reply->str);
+				msg = pstrdup(rctx->r_reply->str);
 
 				ERR_CLEANUP(rctx->r_reply, rctx->r_ctx,
 				    (ERROR, "Redis returned error: %s", msg));


### PR DESCRIPTION
older compilers complained with:
redis_fdw.c:3053:5: error: a label can only be part of a statement and a declaration is not a statement

apparently, it is not allowed to declare anything after label, and apparently default is considered a label?